### PR TITLE
feat(routes): basic game routes

### DIFF
--- a/sql/collect_user.sql
+++ b/sql/collect_user.sql
@@ -1,5 +1,5 @@
 UPDATE users
 SET "balance" = $2,
-  "level" = $3
+  "collected_timestamp" = $3
 WHERE "username" = $1
 RETURNING *;

--- a/sql/update_upgrade_user.sql
+++ b/sql/update_upgrade_user.sql
@@ -1,0 +1,5 @@
+UPDATE users
+SET "balance" = $2,
+  "level" = $3
+WHERE "username" = $1
+RETURNING *;

--- a/sql/upgrade_user.sql
+++ b/sql/upgrade_user.sql
@@ -1,0 +1,5 @@
+UPDATE users
+SET "balance" = $2,
+  "level" = $3
+WHERE "username" = $1
+RETURNING *;

--- a/sql/users.sql
+++ b/sql/users.sql
@@ -3,6 +3,7 @@ CREATE TABLE "users" (
     "hashed_password" TEXT NOT NULL UNIQUE,
     "salt" TEXT NOT NULL,
     "balance" DOUBLE PRECISION DEFAULT 0,
+    "level" INTEGER DEFAULT 0,
     "collected_timestamp" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT "users_pkey" PRIMARY KEY ("username")
 );

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use crate::models::User;
 use deadpool_postgres::Client;
 use tokio_pg_mapper::{Error, FromTokioPostgresRow};
@@ -43,6 +45,47 @@ pub async fn create_user(
         .query(
             &stmt,
             &[&username, &token, &salt],
+        )
+        .await?
+        .pop()
+        .ok_or(Error::ColumnNotFound)?;
+
+    User::from_row_ref(&queried_data)
+}
+
+pub async fn update_collect_user(
+    client: &Client,
+    username: &str,
+    balance: f64,
+) -> Result<User, Error> {
+    let _stmt = include_str!("../sql/update_collect_user.sql");
+    let stmt = client.prepare(_stmt).await?;
+
+    let queried_data = client
+        .query(
+            &stmt,
+            &[&username, &balance, &SystemTime::now()],
+        )
+        .await?
+        .pop()
+        .ok_or(Error::ColumnNotFound)?;
+
+    User::from_row_ref(&queried_data)
+}
+
+pub async fn update_upgrade_user(
+    client: &Client,
+    username: &str,
+    balance: f64,
+    level: i32,
+) -> Result<User, Error> {
+    let _stmt = include_str!("../sql/update_upgrade_user.sql");
+    let stmt = client.prepare(_stmt).await?;
+
+    let queried_data = client
+        .query(
+            &stmt,
+            &[&username, &balance, &level],
         )
         .await?
         .pop()

--- a/src/db.rs
+++ b/src/db.rs
@@ -53,12 +53,12 @@ pub async fn create_user(
     User::from_row_ref(&queried_data)
 }
 
-pub async fn update_collect_user(
+pub async fn collect_user(
     client: &Client,
     username: &str,
     balance: f64,
 ) -> Result<User, Error> {
-    let _stmt = include_str!("../sql/update_collect_user.sql");
+    let _stmt = include_str!("../sql/collect_user.sql");
     let stmt = client.prepare(_stmt).await?;
 
     let queried_data = client
@@ -73,13 +73,13 @@ pub async fn update_collect_user(
     User::from_row_ref(&queried_data)
 }
 
-pub async fn update_upgrade_user(
+pub async fn upgrade_user(
     client: &Client,
     username: &str,
     balance: f64,
     level: i32,
 ) -> Result<User, Error> {
-    let _stmt = include_str!("../sql/update_upgrade_user.sql");
+    let _stmt = include_str!("../sql/upgrade_user.sql");
     let stmt = client.prepare(_stmt).await?;
 
     let queried_data = client

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,8 +32,18 @@ pub struct NotAuthorized;
 
 impl warp::reject::Reject for NotAuthorized {}
 
+#[derive(Debug)]
+pub struct NotEnoughMoney;
+
+impl warp::reject::Reject for NotEnoughMoney {}
+
 pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, std::convert::Infallible> {
-    if err.is_not_found() {
+    if err.find::<NotEnoughMoney>().is_some() {
+        Ok(crate::warp_reply!(
+            "Not enough money to upgrade",
+            BAD_REQUEST
+        ))
+    } else if err.find::<NotFound>().is_some() {
         Ok(crate::warp_reply!(
             "There is no user with that name".to_owned(),
             NOT_FOUND
@@ -42,13 +52,13 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, std::convert
         Ok(crate::warp_reply!(format!("{:?}", e), BAD_REQUEST))
     } else if err.find::<NotAuthorized>().is_some() {
         Ok(crate::warp_reply!(
-            "The password is incorrect".to_string(),
+            "The password is incorrect".to_owned(),
             UNAUTHORIZED
         ))
     }
     else if err.find::<Conflict>().is_some() {
         Ok(crate::warp_reply!(
-            "The provided username already exists".to_string(),
+            "The provided username already exists".to_owned(),
             CONFLICT
         ))
     } else {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,7 +41,7 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, std::convert
     if err.find::<NotEnoughMoney>().is_some() {
         Ok(crate::warp_reply!(
             "Not enough money to upgrade".to_owned(),
-            BAD_REQUEST
+            FORBIDDEN
         ))
     } else if err.find::<NotFound>().is_some() {
         Ok(crate::warp_reply!(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,7 +40,7 @@ impl warp::reject::Reject for NotEnoughMoney {}
 pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, std::convert::Infallible> {
     if err.find::<NotEnoughMoney>().is_some() {
         Ok(crate::warp_reply!(
-            "Not enough money to upgrade",
+            "Not enough money to upgrade".to_owned(),
             BAD_REQUEST
         ))
     } else if err.find::<NotFound>().is_some() {

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,6 +9,7 @@ pub struct User {
     pub hashed_password: String,
     pub salt: String,
     pub balance: f64,
+    pub level: i32,
     pub collected_timestamp: SystemTime,
 }
 
@@ -17,6 +18,7 @@ impl From<User> for UserWithoutSecrets {
         UserWithoutSecrets {
             username: user.username,
             balance: user.balance,
+            level: user.level,
             collected_timestamp: user.collected_timestamp,
         }
     }
@@ -26,5 +28,68 @@ impl From<User> for UserWithoutSecrets {
 pub struct UserWithoutSecrets {
     pub username: String,
     pub balance: f64,
+    pub level: i32,
     pub collected_timestamp: SystemTime,
+}
+
+pub struct UpgradeableLevelsOutput {
+    pub level: i32,
+    pub cost: f64,
+}
+
+pub trait GameCalculations {
+    const BASE_COST: f64;
+    const BASE_PRODUCTION: f64;
+    const COST_MULTIPLIER: f64;
+    const PRODUCTION_MULTIPLIER: f64;
+
+    fn get_production(&self) -> f64;
+    fn next_level_cost(&self) -> f64;
+    fn specific_level_cost(&self, level: i32) -> f64;
+    fn upgradeable_levels(&self) -> Result<UpgradeableLevelsOutput, ()>;
+}
+
+impl GameCalculations for User {
+    const BASE_COST: f64 = 5.0;
+    const BASE_PRODUCTION: f64 = 1.0;
+    const COST_MULTIPLIER: f64 = 1.15;
+    const PRODUCTION_MULTIPLIER: f64 = 1.1;
+
+    /// calculates the production of the user
+    fn get_production(&self) -> f64 {
+        let mut production = Self::BASE_PRODUCTION;
+        for progressed_level in 1..self.level {
+            production += Self::BASE_PRODUCTION * Self::PRODUCTION_MULTIPLIER.powi(progressed_level);
+        }
+        production
+    }
+
+    /// Calculates the cost of the next level
+    fn next_level_cost(&self) -> f64 {
+        Self::BASE_COST * Self::COST_MULTIPLIER.powi(self.level)
+    }
+
+    /// Calculates the cost of a specific level, but keep in mind that this calculates by the level after the specified level.
+    fn specific_level_cost(&self, level: i32) -> f64 {
+        Self::BASE_COST * Self::COST_MULTIPLIER.powi(level)
+    }
+
+    /// Calculates the amount of possible levels you can upgrade to.
+    fn upgradeable_levels(&self) -> Result<UpgradeableLevelsOutput, ()> {
+        let mut level = self.level;
+        let mut cost = self.next_level_cost();
+
+        if self.balance < cost {
+            return Err(());
+        }
+
+        while self.balance >= cost {
+            level += 1;
+            cost += self.specific_level_cost(self.level);
+        }
+        level -= 1;
+        cost -= self.specific_level_cost(self.level);
+
+        Ok(UpgradeableLevelsOutput { level, cost })
+    }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -59,19 +59,19 @@ impl GameCalculations for User {
     fn get_production(&self) -> f64 {
         let mut production = Self::BASE_PRODUCTION;
         for progressed_level in 1..=self.level {
-            production += Self::BASE_PRODUCTION * Self::PRODUCTION_MULTIPLIER.powi(progressed_level);
+            production += (Self::BASE_PRODUCTION * Self::PRODUCTION_MULTIPLIER.powi(progressed_level)).round();
         }
         production
     }
 
     /// Calculates the cost of the next level
     fn next_level_cost(&self) -> f64 {
-        Self::BASE_COST * Self::COST_MULTIPLIER.powi(self.level)
+        (Self::BASE_COST * Self::COST_MULTIPLIER.powi(self.level)).round()
     }
 
     /// Calculates the cost of a specific level, but keep in mind that this calculates by the level after the specified level.
     fn specific_level_cost(&self, level: i32) -> f64 {
-        Self::BASE_COST * Self::COST_MULTIPLIER.powi(level)
+        (Self::BASE_COST * Self::COST_MULTIPLIER.powi(level)).round()
     }
 
     /// Calculates the amount of possible levels you can upgrade to.
@@ -137,9 +137,9 @@ mod tests {
             collected_timestamp: SystemTime::now(),
         };
 
-        assert_eq!(user.specific_level_cost(1), 5.0 * 1.15);
-        assert_eq!(user.specific_level_cost(2), 5.0 * 1.15 * 1.15);
-        assert_eq!(user.specific_level_cost(3), 5.0 * 1.15 * 1.15 * 1.15);
+        assert_eq!(user.specific_level_cost(1), (5.0_f64 * 1.15).round());
+        assert_eq!(user.specific_level_cost(2), (5.0_f64 * 1.15 * 1.15).round());
+        assert_eq!(user.specific_level_cost(3), (5.0_f64 * 1.15 * 1.15 * 1.15).round());
     }
 
     #[test]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -9,7 +9,7 @@ use warp::{Rejection, Reply};
 use crate::{
     auth,
     errors::*,
-    models::{User, UserWithoutSecrets, GameCalculations},
+    models::{GameCalculations, User, UserWithoutSecrets},
 };
 
 /// Authorizes a user based on a Basic Auth header
@@ -18,10 +18,7 @@ pub async fn authorize(
     auth_header: String,
 ) -> Result<(deadpool_postgres::Pool, User), Rejection> {
     let auth::Auth { username, password } = auth::validate_header(auth_header.as_str())?;
-    let pool = db_pool
-        .get()
-        .await
-        .to_internal_error()?;
+    let pool = db_pool.get().await.to_internal_error()?;
 
     let user = crate::db::get_user_by_username(&pool, &username)
         .await
@@ -54,10 +51,7 @@ pub async fn create_account(
     auth_header: String,
 ) -> Result<impl Reply, Rejection> {
     let auth::Auth { username, password } = auth::validate_header(auth_header.as_str())?;
-    let pool = db_pool
-        .get()
-        .await
-        .to_internal_error()?;
+    let pool = db_pool.get().await.to_internal_error()?;
 
     let user = crate::db::get_user_by_username(&pool, &username)
         .await
@@ -87,48 +81,45 @@ pub async fn create_account(
 
 /// Collect money for a user by multiplying their production by the time since last collection and then adding it to their balance
 pub async fn collect(
-    db_pool: deadpool_postgres::Pool,
-    auth_header: String,
+    (db_pool, user): (deadpool_postgres::Pool, User),
 ) -> Result<impl Reply, Rejection> {
-    let auth::Auth { username, password: _ } = auth::validate_header(auth_header.as_str())?;
-    let pool = db_pool
-        .get()
+    let pool = db_pool.get().await.to_internal_error()?;
+
+    let new_balance = user.balance
+        + user.get_production()
+            * user
+                .collected_timestamp
+                .duration_since(SystemTime::now())
+                .to_internal_error()?
+                .as_secs_f64();
+
+    let updated_user = crate::db::collect_user(&pool, &user.username, new_balance)
         .await
         .to_internal_error()?;
-
-    let user = crate::db::get_user_by_username(&pool, &username).await.to_internal_error()?;
-
-    let new_balance = user.balance + user.get_production() * user.collected_timestamp.duration_since(SystemTime::now()).to_internal_error()?.as_secs_f64();
-
-    let updated_user = crate::db::update_collect_user(&pool, &username, new_balance).await.to_internal_error()?;
 
     Ok(warp::reply::json(&updated_user))
 }
 
 /// Upgrade the user's levels
-/// 
+///
 /// This will return a 403 if the user does not have enough money to upgrade
 pub async fn upgrade(
-    db_pool: deadpool_postgres::Pool,
-    auth_header: String,
+    (db_pool,
+    user): (deadpool_postgres::Pool, User),
 ) -> Result<impl Reply, Rejection> {
-    let auth::Auth { username, password: _ } = auth::validate_header(auth_header.as_str())?;
-    let pool = db_pool
-        .get()
-        .await
-        .to_internal_error()?;
-
-    let user = crate::db::get_user_by_username(&pool, &username).await.to_internal_error()?;
+    let pool = db_pool.get().await.to_internal_error()?;
 
     let upgrade = user.upgradeable_levels();
 
-    if upgrade.is_err() {
-        return Err(warp::reject::custom(NotEnoughMoney));
-    }
+    let upgrade = match upgrade {
+        Ok(upgrade) => upgrade,
+        Err(_) => return Err(warp::reject::custom(NotEnoughMoney)),
+    };
 
-    let upgrade = upgrade.unwrap();
-
-    let updated_user = crate::db::update_upgrade_user(&pool, &username, user.balance - upgrade.cost, upgrade.level).await.to_internal_error()?;
+    let updated_user =
+        crate::db::upgrade_user(&pool, &user.username, user.balance - upgrade.cost, upgrade.level)
+            .await
+            .to_internal_error()?;
 
     Ok(warp::reply::json(&updated_user))
 }


### PR DESCRIPTION
Implements `collect` and `upgrade` routes that allow for playing a very basic idle game.

- `collect` route that collects the user's production by comparing the last time they've collected to the current time
- `upgrade` route that upgrades the user's levels to the max amount of levels they're able to purchase with their balance
- `GameCalculations` trait implementation on the User model to access functions for quickly completing game-related actions
- `NotEnoughMoney` error struct that will be returned from the `upgrade` route if the user doesn't have enough in their balance for a level